### PR TITLE
Don't swallow exceptions when applying LagomApp

### DIFF
--- a/src/main/java/com/lightbend/rp/LagomApp.java
+++ b/src/main/java/com/lightbend/rp/LagomApp.java
@@ -4,6 +4,7 @@ import org.apache.maven.project.MavenProject;
 import org.json.*;
 
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.List;
@@ -87,8 +88,13 @@ public class LagomApp implements ReactiveApp {
 
             String servicesJson = (String)services.invoke(sdObj, ld);
             parseServices(servicesJson);
-        } catch(Exception e) {
-            throw new RuntimeException(e.toString());
+        } catch (final InvocationTargetException e) {
+            throwUnchecked(e.getCause());
+        } catch (final Exception e) {
+            throwUnchecked(e);
         }
     }
+
+    @SuppressWarnings("unchecked")
+    private <T extends Throwable> void throwUnchecked(final Throwable e) throws T { throw (T) e; }
 }


### PR DESCRIPTION
Instead throw the InvocationTargetException's cause,
and rethrow any other checked exception as unchecked!

Transforms:

    [ERROR] Failed to execute goal com.lightbend.rp:reactive-app-maven-plugin:0.3.0:build (build-docker) on project front-end: Execution build-docker of goal com.lightbend.rp:reactive-app-maven-plugin:0.3.0:build failed: java.lang.reflect.InvocationTargetException -> [Help 1]
    org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.lightbend.rp:reactive-app-maven-plugin:0.3.0:build (build-docker) on project front-end: Execution build-docker of goal com.lightbend.rp:reactive-app-maven-plugin:0.3.0:build failed: java.lang.reflect.InvocationTargetException
     18 <project xmlns="http://maven.apache.org/POM/4.0.0"$
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:213)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:154)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:146)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
        at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
        at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
        at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
        at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
        at org.apache.maven.cli.MavenCli.execute (MavenCli.java:954)
        at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:288)
        at org.apache.maven.cli.MavenCli.main (MavenCli.java:192)
        at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke (Method.java:498)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:289)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:229)
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:415)
        at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:356)
    Caused by: org.apache.maven.plugin.PluginExecutionException: Execution build-docker of goal com.lightbend.rp:reactive-app-maven-plugin:0.3.0:build failed: java.lang.reflect.InvocationTargetException
        at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:148)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:208)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:154)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:146)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
        at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
        at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
        at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
        at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
        at org.apache.maven.cli.MavenCli.execute (MavenCli.java:954)
        at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:288)
        at org.apache.maven.cli.MavenCli.main (MavenCli.java:192)
        at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke (Method.java:498)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:289)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:229)
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:415)
        at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:356)
    Caused by: java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
        at com.lightbend.rp.LagomApp.apply (LagomApp.java:91)
        at com.lightbend.rp.BuildMojo.execute (BuildMojo.java:79)
        at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:208)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:154)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:146)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
        at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
        at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
        at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
        at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
        at org.apache.maven.cli.MavenCli.execute (MavenCli.java:954)
        at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:288)
        at org.apache.maven.cli.MavenCli.main (MavenCli.java:192)
        at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke (Method.java:498)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:289)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:229)
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:415)
        at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:356)

  into:

    [ERROR] Failed to execute goal com.lightbend.rp:reactive-app-maven-plugin:0.3.1-SNAPSHOT:build (build-docker) on project front-end: A type incompatibility occurred while executing com.lightbend.rp:reactive-app-maven-plugin:0.3.1-SNAPSHOT:build: class play.api.inject.guice.GuiceApplicationLoader
    [ERROR] -----------------------------------------------------
    [ERROR] realm =    plugin>com.lightbend.rp:reactive-app-maven-plugin:0.3.1-SNAPSHOT
    [ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
    [ERROR] urls[0] = file:/Users/dnw/.m2/repository/com/lightbend/rp/reactive-app-maven-plugin/0.3.1-SNAPSHOT/reactive-app-maven-plugin-0.3.1-SNAPSHOT.jar
    [ERROR] urls[1] = file:/Users/dnw/.m2/repository/javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar
    [ERROR] urls[2] = file:/Users/dnw/.m2/repository/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.0/org.eclipse.sisu.inject-0.3.0.jar
    [ERROR] urls[3] = file:/Users/dnw/.m2/repository/org/apache/maven/maven-builder-support/3.3.1/maven-builder-support-3.3.1.jar
    [ERROR] urls[4] = file:/Users/dnw/.m2/repository/com/google/guava/guava/18.0/guava-18.0.jar
    [ERROR] urls[5] = file:/Users/dnw/.m2/repository/org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.jar
    [ERROR] urls[6] = file:/Users/dnw/.m2/repository/org/sonatype/sisu/sisu-guice/3.2.5/sisu-guice-3.2.5-no_aop.jar
    [ERROR] urls[7] = file:/Users/dnw/.m2/repository/aopalliance/aopalliance/1.0/aopalliance-1.0.jar
    [ERROR] urls[8] = file:/Users/dnw/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar
    [ERROR] urls[9] = file:/Users/dnw/.m2/repository/org/codehaus/plexus/plexus-utils/3.0.20/plexus-utils-3.0.20.jar
    [ERROR] urls[10] = file:/Users/dnw/.m2/repository/org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar
    [ERROR] urls[11] = file:/Users/dnw/.m2/repository/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar
    [ERROR] urls[12] = file:/Users/dnw/.m2/repository/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar
    [ERROR] urls[13] = file:/Users/dnw/.m2/repository/org/apache/maven/plugin-tools/maven-plugin-annotations/3.2/maven-plugin-annotations-3.2.jar
    [ERROR] urls[14] = file:/Users/dnw/.m2/repository/org/twdata/maven/mojo-executor/2.2.0/mojo-executor-2.2.0.jar
    [ERROR] urls[15] = file:/Users/dnw/.m2/repository/org/json/json/20180130/json-20180130.jar
    [ERROR] urls[16] = file:/Users/dnw/.m2/repository/com/github/zafarkhaja/java-semver/0.9.0/java-semver-0.9.0.jar
    [ERROR] Number of foreign imports: 1
    [ERROR] import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
    [ERROR]
    [ERROR] -----------------------------------------------------
    [ERROR]
    [ERROR] -> [Help 1]
    org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.lightbend.rp:reactive-app-maven-plugin:0.3.1-SNAPSHOT:build (build-docker) on project front-end: A type incompatibility occurred while executing com.lightbend.rp:reactive-app-maven-plugin:0.3.1-SNAPSHOT:build: class play.api.inject.guice.GuiceApplicationLoader
    -----------------------------------------------------
    realm =    plugin>com.lightbend.rp:reactive-app-maven-plugin:0.3.1-SNAPSHOT
    strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
    urls[0] = file:/Users/dnw/.m2/repository/com/lightbend/rp/reactive-app-maven-plugin/0.3.1-SNAPSHOT/reactive-app-maven-plugin-0.3.1-SNAPSHOT.jar
    urls[1] = file:/Users/dnw/.m2/repository/javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar
    urls[2] = file:/Users/dnw/.m2/repository/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.0/org.eclipse.sisu.inject-0.3.0.jar
    urls[3] = file:/Users/dnw/.m2/repository/org/apache/maven/maven-builder-support/3.3.1/maven-builder-support-3.3.1.jar
    urls[4] = file:/Users/dnw/.m2/repository/com/google/guava/guava/18.0/guava-18.0.jar
    urls[5] = file:/Users/dnw/.m2/repository/org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.jar
    urls[6] = file:/Users/dnw/.m2/repository/org/sonatype/sisu/sisu-guice/3.2.5/sisu-guice-3.2.5-no_aop.jar
    urls[7] = file:/Users/dnw/.m2/repository/aopalliance/aopalliance/1.0/aopalliance-1.0.jar
    urls[8] = file:/Users/dnw/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar
    urls[9] = file:/Users/dnw/.m2/repository/org/codehaus/plexus/plexus-utils/3.0.20/plexus-utils-3.0.20.jar
    urls[10] = file:/Users/dnw/.m2/repository/org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar
    urls[11] = file:/Users/dnw/.m2/repository/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar
    urls[12] = file:/Users/dnw/.m2/repository/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar
    urls[13] = file:/Users/dnw/.m2/repository/org/apache/maven/plugin-tools/maven-plugin-annotations/3.2/maven-plugin-annotations-3.2.jar
    urls[14] = file:/Users/dnw/.m2/repository/org/twdata/maven/mojo-executor/2.2.0/mojo-executor-2.2.0.jar
    urls[15] = file:/Users/dnw/.m2/repository/org/json/json/20180130/json-20180130.jar
    urls[16] = file:/Users/dnw/.m2/repository/com/github/zafarkhaja/java-semver/0.9.0/java-semver-0.9.0.jar
    Number of foreign imports: 1
    import: Entry[import  from realm ClassRealm[maven.api, parent: null]]

    -----------------------------------------------------

        at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:213)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:154)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:146)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
        at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
        at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
        at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
        at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
        at org.apache.maven.cli.MavenCli.execute (MavenCli.java:954)
        at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:288)
        at org.apache.maven.cli.MavenCli.main (MavenCli.java:192)
        at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke (Method.java:498)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:289)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:229)
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:415)
        at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:356)
    Caused by: org.apache.maven.plugin.PluginExecutionException: A type incompatibility occurred while executing com.lightbend.rp:reactive-app-maven-plugin:0.3.1-SNAPSHOT:build: class play.api.inject.guice.GuiceApplicationLoader
    -----------------------------------------------------
    realm =    plugin>com.lightbend.rp:reactive-app-maven-plugin:0.3.1-SNAPSHOT
    strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
    urls[0] = file:/Users/dnw/.m2/repository/com/lightbend/rp/reactive-app-maven-plugin/0.3.1-SNAPSHOT/reactive-app-maven-plugin-0.3.1-SNAPSHOT.jar
    urls[1] = file:/Users/dnw/.m2/repository/javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar
    urls[2] = file:/Users/dnw/.m2/repository/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.0/org.eclipse.sisu.inject-0.3.0.jar
    urls[3] = file:/Users/dnw/.m2/repository/org/apache/maven/maven-builder-support/3.3.1/maven-builder-support-3.3.1.jar
    urls[4] = file:/Users/dnw/.m2/repository/com/google/guava/guava/18.0/guava-18.0.jar
    urls[5] = file:/Users/dnw/.m2/repository/org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.jar
    urls[6] = file:/Users/dnw/.m2/repository/org/sonatype/sisu/sisu-guice/3.2.5/sisu-guice-3.2.5-no_aop.jar
    urls[7] = file:/Users/dnw/.m2/repository/aopalliance/aopalliance/1.0/aopalliance-1.0.jar
    urls[8] = file:/Users/dnw/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar
    urls[9] = file:/Users/dnw/.m2/repository/org/codehaus/plexus/plexus-utils/3.0.20/plexus-utils-3.0.20.jar
    urls[10] = file:/Users/dnw/.m2/repository/org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar
    urls[11] = file:/Users/dnw/.m2/repository/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar
    urls[12] = file:/Users/dnw/.m2/repository/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar
    urls[13] = file:/Users/dnw/.m2/repository/org/apache/maven/plugin-tools/maven-plugin-annotations/3.2/maven-plugin-annotations-3.2.jar
    urls[14] = file:/Users/dnw/.m2/repository/org/twdata/maven/mojo-executor/2.2.0/mojo-executor-2.2.0.jar
    urls[15] = file:/Users/dnw/.m2/repository/org/json/json/20180130/json-20180130.jar
    urls[16] = file:/Users/dnw/.m2/repository/com/github/zafarkhaja/java-semver/0.9.0/java-semver-0.9.0.jar
    Number of foreign imports: 1
    import: Entry[import  from realm ClassRealm[maven.api, parent: null]]

    -----------------------------------------------------

        at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:199)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:208)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:154)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:146)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
        at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
        at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
        at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
        at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
        at org.apache.maven.cli.MavenCli.execute (MavenCli.java:954)
        at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:288)
        at org.apache.maven.cli.MavenCli.main (MavenCli.java:192)
        at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke (Method.java:498)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:289)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:229)
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:415)
        at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:356)
    Caused by: java.lang.ClassCastException: class play.api.inject.guice.GuiceApplicationLoader
        at java.lang.Class.asSubclass (Class.java:3404)
        at com.lightbend.lagom.internal.api.tools.ServiceDetector$.services (ServiceDetector.scala:58)
        at com.lightbend.lagom.internal.api.tools.ServiceDetector$.services (ServiceDetector.scala:51)
        at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke (Method.java:498)
        at com.lightbend.rp.LagomApp.apply (LagomApp.java:89)
        at com.lightbend.rp.BuildMojo.execute (BuildMojo.java:79)
        at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:208)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:154)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:146)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
        at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
        at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
        at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
        at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
        at org.apache.maven.cli.MavenCli.execute (MavenCli.java:954)
        at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:288)
        at org.apache.maven.cli.MavenCli.main (MavenCli.java:192)
        at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke (Method.java:498)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:289)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:229)
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:415)
        at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:356)