### PR TITLE
Make it work on Lagom

### DIFF
--- a/src/it/lagom-endpoints/hello-impl/pom.xml
+++ b/src/it/lagom-endpoints/hello-impl/pom.xml
@@ -27,6 +27,10 @@
         </dependency>
         <dependency>
             <groupId>com.lightbend.lagom</groupId>
+            <artifactId>lagom-logback_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.lightbend.lagom</groupId>
             <artifactId>api-tools_${scala.binary.version}</artifactId>
             <version>${lagom.version}</version>
         </dependency>
@@ -43,6 +47,11 @@
         <dependency>
             <groupId>com.lightbend.rp</groupId>
             <artifactId>reactive-lib-akka-cluster-bootstrap_${scala.binary.version}</artifactId>
+            <version>0.9.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.lightbend.rp</groupId>
+            <artifactId>reactive-lib-play-http-binding_${scala.binary.version}</artifactId>
             <version>0.9.0</version>
         </dependency>
 

--- a/src/it/lagom-endpoints/hello-impl/src/main/resources/application.conf
+++ b/src/it/lagom-endpoints/hello-impl/src/main/resources/application.conf
@@ -4,3 +4,8 @@ play.crypto.secret = whatever
 lagom.services {
   hello-impl = "http://localhost:9000"
 }
+
+play.modules.enabled +=
+  "com.lightbend.rp.servicediscovery.lagom.javadsl.ServiceLocatorModule"
+
+play.filters.disabled+=play.filters.hosts.AllowedHostsFilter

--- a/src/main/java/com/lightbend/rp/LagomApp.java
+++ b/src/main/java/com/lightbend/rp/LagomApp.java
@@ -24,6 +24,7 @@ public class LagomApp implements ReactiveApp {
         settings.enableCommon = true;
         settings.enableAkkaClusterBootstrap = true;
         settings.enableServiceDiscovery = true;
+        settings.enablePlayHttpBinding = true;
         settings.mainClass = "play.core.server.ProdServerStart";
     }
 


### PR DESCRIPTION
1. We need ServiceLocatorModule for Lagom.
2. We also need Play HTTP Binding enabled for Lagom, which includes magical configuration file from reactive-lib, which uses environment variable naming convention to configure the port number.

Finally, I have Lagom working in Minikube:

```
$ http --follow --verify=no https://192.168.99.100/api/hello/world
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 12
Content-Type: text/plain
Date: Mon, 13 Aug 2018 05:27:34 GMT
Server: nginx/1.13.12

hello: world
```
