### PR TITLE
Implement integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
 - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lcomponent=kube-addon-manager -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-addon-manager to be available"; kubectl get pods --all-namespaces; done
 # Wait for kube-dns to be ready.
 - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-dns to be available"; kubectl get pods --all-namespaces; done
-- bin/run-integration-tests.sh
+- bin/run-integration-tests.sh -x
 
 # TODO: Add caching of $HOME/.m2/repository without compromising the integrity of CI
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_script:
 - sudo minikube start --vm-driver=none --bootstrapper=localkube --kubernetes-version=v1.10.0
 # Fix the kubectl context, as it's often stale.
 - minikube update-context
+- sudo minikube addons enable ingress
 # Wait for Kubernetes to be up and ready.
 - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
 

--- a/bin/run-integration-tests.sh
+++ b/bin/run-integration-tests.sh
@@ -94,7 +94,7 @@ it_test() {
 mvn -DskipTests=true -Dmaven.javadoc.skip=true -Dgpg.skip=true install
 bin/sync-integration-tests-plugin-version.sh || die "Failed to sync integration tests plugin version"
 # it_test src/it/hello           hello:1.0
-it_test src/it/akka-quickstart akka-quickstart:1.0
-it_test src/it/play-endpoints  play-endpoints:1.0
-it_test src/it/lagom-endpoints hello-impl:1.0
-it_test src/it/akka-cluster    akka-cluster:1.0
+it_test src/it/akka-quickstart akka-quickstart:1.0  || die "it_test fail"
+it_test src/it/play-endpoints  play-endpoints:1.0   || die "it_test fail"
+it_test src/it/lagom-endpoints hello-impl:1.0       || die "it_test fail"
+it_test src/it/akka-cluster    akka-cluster:1.0     || die "it_test fail"

--- a/bin/run-integration-tests.sh
+++ b/bin/run-integration-tests.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 
+# Usage
+# `bin/run-integration-tests.sh`          for dry run
+# `bin/run-integration-tests.sh --deploy` to run it on minikube
+
 set -o pipefail
+
+dry_run=true;
+
+case "$1" in
+  -x|--deploy) dry_run=false; echo "deploy mode!";;
+  *) ;;
+esac
 
 die() { echo "Aborting: $*"; exit 1; }
 
@@ -26,6 +37,17 @@ it_test() {
   (
     cd "$dir" || die "Failed to cd into $dir"
 
+    if ! (($dry_run)); then
+      echo "Resetting minikube"
+      kubectl get services --no-headers | grep -v "^kube.*" | awk '{print $1}' | xargs kubectl delete service
+      kubectl delete ingress --all
+      kubectl delete deployment --all
+
+      # minikube delete
+      # minikube start
+      # eval $(minikube docker-env)
+    fi
+
     mvn -DskipTests=true -Dmaven.javadoc.skip=true -Dgpg.skip=true clean install
 
     echo "Generating K8s resources for $docker_image and applying with kubectl"
@@ -33,8 +55,20 @@ it_test() {
     "$RP" generate-kubernetes-resources --generate-all --registry-use-local "$docker_image" > "$file" \
       || die "Failed to generate k8s resources for $docker_image"
 
-    kubectl apply --validate --dry-run -f "$file" \
-      || die "Failed to apply k8s resources for $docker_image"
+    if ($dry_run); then
+      kubectl apply --validate --dry-run -f "$file" \
+        || die "Failed to apply k8s resources for $docker_image"
+    else
+      kubectl apply --validate -f "$file" \
+        || die "Failed to apply k8s resources for $docker_image"
+
+      while ! (kubectl get pods --no-headers | grep "\bRunning\b"); do
+        echo "[info] waiting..."
+        sleep 1
+      done
+      echo "[info] deployed"
+      sleep 5
+    fi
 
     if [ -f "check.sh" ]; then
       echo "Running check.sh script"
@@ -44,13 +78,22 @@ it_test() {
         die "Dockerfile check failed"
       fi
     fi
+
+    if [ -f "test.sh" ]; then
+      echo "Running test.sh script"
+      if ./test.sh; then
+        echo "Integration test successful"
+      else
+        die "Integration test failed"
+      fi
+    fi
   )
 }
 
 # prerequisite: minikube start & eval $(minikube docker-env)
 mvn -DskipTests=true -Dmaven.javadoc.skip=true -Dgpg.skip=true install
 bin/sync-integration-tests-plugin-version.sh || die "Failed to sync integration tests plugin version"
-it_test src/it/hello           hello:1.0
+# it_test src/it/hello           hello:1.0
 it_test src/it/akka-quickstart akka-quickstart:1.0
 it_test src/it/play-endpoints  play-endpoints:1.0
 it_test src/it/lagom-endpoints hello-impl:1.0

--- a/src/it/play-endpoints/pom.xml
+++ b/src/it/play-endpoints/pom.xml
@@ -115,6 +115,13 @@
                 </configuration>
                 <executions>
                     <execution>
+                        <id>merge-config</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>merge-config</goal>
+                        </goals>
+                    </execution>
+                    <execution>
                         <goals>
                             <goal>build</goal>
                         </goals>

--- a/src/it/play-endpoints/test.sh
+++ b/src/it/play-endpoints/test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+curl -kL --fail "https://$(minikube ip)/" | grep "Hello.*"

--- a/src/main/java/com/lightbend/rp/MergeConfigMojo.java
+++ b/src/main/java/com/lightbend/rp/MergeConfigMojo.java
@@ -53,8 +53,7 @@ public class MergeConfigMojo extends AbstractMojo {
         Xpp3Dom pluginConf = (Xpp3Dom)getThisPlugin().getConfiguration();
         Settings settings = new Settings();
         settings.read(pluginConf);
-        if(settings.enableAkkaClusterBootstrap
-            || settings.enableStatus) {
+        if(settings.enableCommon) {
             log.info("Executing merge-config");
             try {
                 mergeConfigFiles(log);


### PR DESCRIPTION
This adds `-x` option to `bin/run-integration-tests.sh` that actually deploys the apps to the cluster, as opposed to just doing the dry run.

To save time, I'm deleting services, ingress, and deployment each time instead of wiping out the entire minikube.

When `test.sh` is found, it runs the script. Currently only Play implements test:

```bash
curl -kL --fail "https://$(minikube ip)/" | grep "Hello.*"
```

Fixes https://github.com/lightbend/reactive-app-maven-plugin/issues/41
Fixes https://github.com/lightbend/orchestration-team/issues/76